### PR TITLE
Update encoder to the latest version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build/subsettedFonts/cff-fallback.otf build/subsettedFonts/glyf-fallback.ttf &: 
 
 build/config/glyf_segmentation_plan.txtpb: build/subsettedFonts/glyf-ift.ttf encoder/config/segmentation_config.txtpb
 	mkdir -p build/config/
-	cd encoder; bazel run $(BAZEL_OPTS) @ift_encoder//util:closure_glyph_keyed_segmenter_util -- \
+	cd encoder; bazel run $(BAZEL_OPTS) @ift_encoder//util:gen_ift_segmentation_plan -- \
 	      --input_font=$(CURDIR)/build/subsettedFonts/glyf-ift.ttf \
 	      --config=$(CURDIR)/encoder/config/segmentation_config.txtpb \
 	      --nooutput_segmentation_analysis \
@@ -35,7 +35,7 @@ build/config/glyf_segmentation_plan.txtpb: build/subsettedFonts/glyf-ift.ttf enc
 
 build/config/cff_segmentation_plan.txtpb: build/subsettedFonts/cff-ift.otf encoder/config/segmentation_config.txtpb
 	mkdir -p build/config/
-	cd encoder; bazel run $(BAZEL_OPTS) @ift_encoder//util:closure_glyph_keyed_segmenter_util -- \
+	cd encoder; bazel run $(BAZEL_OPTS) @ift_encoder//util:gen_ift_segmentation_plan -- \
 	      --input_font=$(CURDIR)/build/subsettedFonts/cff-ift.otf \
 	      --config=$(CURDIR)/encoder/config/segmentation_config.txtpb \
 	      --nooutput_segmentation_analysis \

--- a/encoder/MODULE.bazel
+++ b/encoder/MODULE.bazel
@@ -1,6 +1,6 @@
 bazel_dep(name = "ift_encoder", version = "git")
-git_override(module_name = "ift_encoder", remote = "https://github.com/garretrieger/ift-encoder.git", commit = "0c9206a6fa0fee5002c285ea453dfd24f2746767")
-git_override(module_name = "ift_encoder_data", remote = "https://github.com/w3c/ift-encoder-data.git", commit = "317ea02ac68d45004aa842f831c65ed33c891701")
+git_override(module_name = "ift_encoder", remote = "https://github.com/garretrieger/ift-encoder.git", commit = "2c22d50e17346a33b01dea2a6c170bc87403cd20")
+git_override(module_name = "ift_encoder_data", remote = "https://github.com/w3c/ift-encoder-data.git", commit = "8f50ef507feac8f8bdf6c39a92f95b7c991dcfda")
 
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "glib", version = "2.82.2.bcr.5")


### PR DESCRIPTION
Notably this includes https://github.com/w3c/ift-encoder/commit/2c22d50e17346a33b01dea2a6c170bc87403cd20 which is needed for issue #35